### PR TITLE
Allowing later versions of mingw from chocolatey

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -154,16 +154,18 @@ runs:
             #      any announcements).
             #   b) It was seemingly built without threading (no <mutex>,
             #      <thread>, etc.).
-            $version = '8.1.0'
+            # $version = '8.1.0'
+            # As of 2022-13-5 this has been fixed and chocolatey distributes
+            # version 11.2.0 which does work
 
             if ($x64) {
                 # If the 32-bit version is installed, we won't detect that.
                 # But it's not that important, and we save a lot of time.
-                Install-Package $pkg --version $version
+                Install-Package $pkg
             } else {
                 # Assuming the 64-bit version is installed.
                 Remove-Package $pkg
-                Install-Package $pkg --version $version --x86
+                Install-Package $pkg --x86
             }
             echo $mingw_bin >> $env:GITHUB_PATH
 


### PR DESCRIPTION
I ran into some code for a PR here: https://github.com/KhronosGroup/KTX-Software/pull/574
Where I needed a newer version of gcc from mingw to avoid some compiler bugs. The newer version of mingw on chocolatey seems to work fine so I removed the explicit versioning